### PR TITLE
ShapeRule 추가

### DIFF
--- a/GCS.WPF/GCS.WPF.csproj
+++ b/GCS.WPF/GCS.WPF.csproj
@@ -54,7 +54,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="GShapes\GDot.cs" />
     <Compile Include="GShapes\GEllipse.cs" />
+    <Compile Include="GShapes\GLine.cs" />
     <Compile Include="GShapes\GShape.cs" />
     <Compile Include="ShapeHelper.cs" />
     <Compile Include="State.cs" />

--- a/GCS.WPF/GCS.WPF.csproj
+++ b/GCS.WPF/GCS.WPF.csproj
@@ -54,6 +54,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="GShapes\GCircle.cs" />
     <Compile Include="GShapes\GDot.cs" />
     <Compile Include="GShapes\GEllipse.cs" />
     <Compile Include="GShapes\GLine.cs" />

--- a/GCS.WPF/GShapes/GCircle.cs
+++ b/GCS.WPF/GShapes/GCircle.cs
@@ -36,6 +36,13 @@ namespace GCS.WPF.GShapes
             Another = another;
         }
 
+        public static GCircle FromTwoDots(GDot center, GDot another)
+        {
+            var circle = new GCircle();
+            new CircleOnTwoDotsRule(circle, center, another);
+            return circle;
+        }
+
         public class CircleOnTwoDotsRule : GShapeRule
         {
             public CircleOnTwoDotsRule(GCircle circle, GDot p1, GDot p2) : base(circle)

--- a/GCS.WPF/GShapes/GCircle.cs
+++ b/GCS.WPF/GShapes/GCircle.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Shapes;
+
+namespace GCS.WPF.GShapes
+{
+    public class GCircle : GShape
+    {
+        public Point Center { get; protected set; }
+        public Point Another { get; protected set; }
+
+        protected override int _attrCount => 2;
+        protected override Point this[int index]
+        {
+            get => new Point[] { Center, Another }[index];
+            set
+            {
+                switch(index)
+                {
+                    case 0: Center = value; return;
+                    case 1: Another = value; return;
+                    default: throw new IndexOutOfRangeException();
+                }
+            }
+        }
+
+        protected GCircle(Ellipse circle = null)
+        {
+            Control = circle ?? new Ellipse();
+        }
+
+        protected GCircle(Point center, Point another) : this()
+        {
+            (Control as Ellipse).SetCircle(center, another);
+            Center = center;
+            Another = another;
+        }
+
+        public class CircleOnTwoDotsRule : GShapeRule
+        {
+            public CircleOnTwoDotsRule(GCircle circle, GDot p1, GDot p2) : base(circle)
+            {
+                SetRelationship(circle, p1, p2);
+            }
+
+            public override void HandleMove()
+            {
+                gShape.Parents[0].MoveTo((gShape as GCircle).Center);
+                gShape.Parents[1].MoveTo((gShape as GCircle).Another);
+            }
+
+            public override void Fix()
+            {
+                (gShape as GCircle).Center = (gShape.Parents[0] as GDot).Coord;
+                (gShape as GCircle).Another = (gShape.Parents[1] as GDot).Coord;
+            }
+        }
+    }
+}

--- a/GCS.WPF/GShapes/GDot.cs
+++ b/GCS.WPF/GShapes/GDot.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Shapes;
+
+namespace GCS.WPF.GShapes
+{
+    public class GDot : GShape
+    {
+        public Point Coord { get; protected set; }
+
+        public GDot(Ellipse dot = null)
+        {
+            Control = dot ?? new Ellipse();
+        }
+
+        public GDot(Point coord) : this()
+        {
+            (Control as Ellipse).SetDot(coord);
+            Coord = coord;
+        }
+    }
+}

--- a/GCS.WPF/GShapes/GDot.cs
+++ b/GCS.WPF/GShapes/GDot.cs
@@ -28,5 +28,10 @@ namespace GCS.WPF.GShapes
             (Control as Ellipse).SetDot(coord);
             Coord = coord;
         }
+
+        public static GDot FromCoord(Point coord)
+        {
+            return new GDot(coord);
+        }
     }
 }

--- a/GCS.WPF/GShapes/GDot.cs
+++ b/GCS.WPF/GShapes/GDot.cs
@@ -6,14 +6,24 @@ namespace GCS.WPF.GShapes
 {
     public class GDot : GShape
     {
+        protected override int _attrCount => 1;
+        protected override Point this[int index]
+        {
+            get => index == 0 ? Coord : throw new IndexOutOfRangeException();
+            set
+            {
+                if (index == 0) Coord = value;
+                else throw new IndexOutOfRangeException();
+            }
+        }
         public Point Coord { get; protected set; }
 
-        public GDot(Ellipse dot = null)
+        protected GDot(Ellipse dot = null)
         {
             Control = dot ?? new Ellipse();
         }
 
-        public GDot(Point coord) : this()
+        protected GDot(Point coord) : this()
         {
             (Control as Ellipse).SetDot(coord);
             Coord = coord;

--- a/GCS.WPF/GShapes/GEllipse.cs
+++ b/GCS.WPF/GShapes/GEllipse.cs
@@ -11,12 +11,28 @@ namespace GCS.WPF.GShapes
         public Point PinPoint { get; protected set; }
         //public Point Center => Point.Add(Focus1, Focus2);
 
-        public GEllipse(Ellipse ellipse = null)
+        protected override int _attrCount => 3;
+        protected override Point this[int index]
+        {
+            get => new Point[] { Focus1, Focus2, PinPoint }[index];
+            set
+            {
+                switch (index)
+                {
+                    case 0: Focus1 = value; return;
+                    case 1: Focus2 = value; return;
+                    case 2: PinPoint = value; return;
+                    default: throw new IndexOutOfRangeException();
+                }
+            }
+        }
+
+        protected GEllipse(Ellipse ellipse = null)
         {
             Control = ellipse ?? new Ellipse();
         }
 
-        public GEllipse(Point focus1, Point focus2, Point pinpoint) : this()
+        protected GEllipse(Point focus1, Point focus2, Point pinpoint) : this()
         {
             (Control as Ellipse).SetThreePoint(focus1, focus2, pinpoint);
             Focus1 = focus1;

--- a/GCS.WPF/GShapes/GEllipse.cs
+++ b/GCS.WPF/GShapes/GEllipse.cs
@@ -11,8 +11,6 @@ namespace GCS.WPF.GShapes
         public Point PinPoint { get; protected set; }
         //public Point Center => Point.Add(Focus1, Focus2);
 
-        public new Ellipse Control { get; protected set; }
-
         public GEllipse(Ellipse ellipse = null)
         {
             Control = ellipse ?? new Ellipse();
@@ -20,7 +18,10 @@ namespace GCS.WPF.GShapes
 
         public GEllipse(Point focus1, Point focus2, Point pinpoint) : this()
         {
-            Control.SetThreePoint(focus1, focus2, pinpoint);
+            (Control as Ellipse).SetThreePoint(focus1, focus2, pinpoint);
+            Focus1 = focus1;
+            Focus2 = focus2;
+            PinPoint = pinpoint;
         }
     }
 }

--- a/GCS.WPF/GShapes/GLine.cs
+++ b/GCS.WPF/GShapes/GLine.cs
@@ -1,0 +1,22 @@
+﻿using System.Windows;
+using System.Windows.Shapes;
+
+namespace GCS.WPF.GShapes
+{
+    public class GLine : GShape
+    {
+        public Point Point1 { get; private set; }
+        public Point Point2 { get; private set; }
+
+        public GLine(Line line = null)
+        {
+            Control = line ?? new Line();
+        }
+
+        public GLine(Point p1, Point p2) : this()
+        {
+            (Control as Line).SetTwoPoint(p1, p2);
+            Point1 = p1; Point2 = p2;
+        }
+    }
+}

--- a/GCS.WPF/GShapes/GLine.cs
+++ b/GCS.WPF/GShapes/GLine.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Shapes;
 
 namespace GCS.WPF.GShapes
@@ -8,15 +9,49 @@ namespace GCS.WPF.GShapes
         public Point Point1 { get; private set; }
         public Point Point2 { get; private set; }
 
-        public GLine(Line line = null)
+        protected override int _attrCount => 2;
+        protected override Point this[int index]
+        {
+            get => new Point[] { Point1, Point2 }[index];
+            set
+            {
+                switch (index)
+                {
+                    case 0: Point1 = value; return;
+                    case 1: Point2 = value; return;
+                    default: throw new IndexOutOfRangeException();
+                }
+            }
+        }
+
+        protected GLine(Line line = null)
         {
             Control = line ?? new Line();
         }
 
-        public GLine(Point p1, Point p2) : this()
+        protected GLine(Point p1, Point p2) : this()
         {
             (Control as Line).SetTwoPoint(p1, p2);
             Point1 = p1; Point2 = p2;
+        }
+
+        public class LineOnTwoDotsRule : GShapeRule
+        {
+            public LineOnTwoDotsRule(GLine line, GDot p1, GDot p2) : base(line)
+            {
+                SetRelationship(line, p1, p2);
+            }
+            public override void HandleMove()
+            {
+                gShape.Parents[0].MoveTo((gShape as GLine).Point1);
+                gShape.Parents[0].MoveTo((gShape as GLine).Point2);
+            }
+
+            public override void Fix()
+            {
+                (gShape as GLine).Point1 = (gShape.Parents[0] as GDot).Coord;
+                (gShape as GLine).Point2 = (gShape.Parents[1] as GDot).Coord;
+            }
         }
     }
 }

--- a/GCS.WPF/GShapes/GLine.cs
+++ b/GCS.WPF/GShapes/GLine.cs
@@ -35,6 +35,13 @@ namespace GCS.WPF.GShapes
             Point1 = p1; Point2 = p2;
         }
 
+        public static GLine FromTwoDots(GDot p1, GDot p2)
+        {
+            var line = new GLine();
+            new LineOnTwoDotsRule(line, p1, p2);
+            return line;
+        }
+
         public class LineOnTwoDotsRule : GShapeRule
         {
             public LineOnTwoDotsRule(GLine line, GDot p1, GDot p2) : base(line)

--- a/GCS.WPF/GShapes/GShape.cs
+++ b/GCS.WPF/GShapes/GShape.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Windows.Shapes;
+using System.Windows;
 
 namespace GCS.WPF.GShapes
 {
@@ -44,7 +45,31 @@ namespace GCS.WPF.GShapes
         }
 
         public Shape Control { get; protected set; }
-        public List<GShape> Childs;
+        public List<GShape> Parents = new List<GShape>();
+        public List<GShape> Childs = new List<GShape>();
         protected GShapeRule _rule;
+
+        protected abstract int _attrCount { get; }
+        protected abstract Point this[int index] { get; set; }
+
+        public void Move(Point delta)
+        {
+            for (int i = 0; i < _attrCount; i++)
+                this[i] += new Vector(delta.X, delta.Y);
+            _rule?.Move();
+        }
+        public void MoveTo(Point to)
+        {
+            Move(to - new Vector(this[0].X, this[0].Y));
+        }
+
+        public static void SetRelationship(GShape parent, params GShape[] childs)
+        {
+            foreach(var c in childs)
+            {
+                parent.Childs.Add(c);
+                c.Parents.Add(parent);
+            }
+        }
     }
 }

--- a/GCS.WPF/GShapes/GShape.cs
+++ b/GCS.WPF/GShapes/GShape.cs
@@ -1,9 +1,50 @@
-﻿using System.Windows.Shapes;
+﻿using System.Collections.Generic;
+using System.Windows.Shapes;
 
 namespace GCS.WPF.GShapes
 {
     public abstract class GShape
     {
+        public abstract class GShapeRule
+        {
+            public GShape gShape;
+            public GShapeRule(GShape shape)
+            {
+                gShape = shape;
+            }
+
+            protected bool _isMoving = false;
+            public void Move()
+            {
+                if (_isMoving) return;
+                _isMoving = true;
+
+                HandleMove();
+
+                Fix();
+                MoveChilds();
+                _isMoving = false;
+            }
+
+            public void MoveChilds()
+            {
+                foreach (var c in gShape.Childs)
+                    c._rule.OnParentMoved();
+            }
+
+            public void OnParentMoved()
+            {
+                if (_isMoving) return;
+                Fix();
+                MoveChilds();
+            }
+
+            public abstract void Fix();
+            public abstract void HandleMove();
+        }
+
         public Shape Control { get; protected set; }
+        public List<GShape> Childs;
+        protected GShapeRule _rule;
     }
 }

--- a/GCS.WPF/MainWindow.xaml.cs
+++ b/GCS.WPF/MainWindow.xaml.cs
@@ -20,7 +20,8 @@ namespace GCS.WPF
     public partial class MainWindow : Window
     {
         private State _currentState;
-        private Point _lastDownedPoint;
+        private GDot _lastDownedPoint;
+        private GDot _movingPoint;
         private GShape _drawingShape;
 
         private List<GShape> _shapes;
@@ -52,20 +53,28 @@ namespace GCS.WPF
             else _currentState = State.NOTDRAWING;
         }
 
+        private GDot GetDot(Point coord)
+        {
+            // TODO: 이전 버전의 GCS의 GetDot과 같은 작동을 하게끔
+            return GDot.FromCoord(coord);
+        }
+
         private void Canvas_MouseDown(object sender, MouseButtonEventArgs e)
         {
+
             _currentState |= State.LEFTMOUSE_DOWN;
             if (_currentState.HasFlag(State.DRAWING))
             {
-                _lastDownedPoint = e.GetPosition(shapeCanvas);
+                _lastDownedPoint = GetDot(e.GetPosition(shapeCanvas));
+                _movingPoint = GDot.FromCoord(e.GetPosition(shapeCanvas));
                 if (_drawingShape == null)
                 {
                     if (_currentState.HasFlag(State.CIRCLE))
-                        _drawingShape = new GEllipse();
+                        _drawingShape = GCircle.FromTwoDots(_lastDownedPoint, _movingPoint);
                     else if (_currentState.HasFlag(State.LINE))
-                        _drawingShape = new GLine();
+                        _drawingShape = GLine.FromTwoDots(_lastDownedPoint, _movingPoint);
                     else if (_currentState.HasFlag(State.DOT))
-                        _drawingShape = new GEllipse();
+                        _drawingShape = _lastDownedPoint;
                     _drawingShape.Control.Stroke = Brushes.Blue;
                     shapeCanvas.Children.Add(_drawingShape.Control);
                 }
@@ -82,11 +91,11 @@ namespace GCS.WPF
             // Preview drawing
             if (_currentState.HasFlag(State.CIRCLE))
             {
-                (_drawingShape.Control as Ellipse).SetCircle(_lastDownedPoint, curPos);
+                (_drawingShape.Control as Ellipse).SetCircle(_lastDownedPoint.Coord, curPos);
             }
             else if (_currentState.HasFlag(State.LINE))
             {
-                (_drawingShape.Control as Line).SetTwoPoint(_lastDownedPoint, curPos);
+                (_drawingShape.Control as Line).SetTwoPoint(_lastDownedPoint.Coord, curPos);
             }
             else if (_currentState.HasFlag(State.DOT))
             {

--- a/GCS.WPF/MainWindow.xaml.cs
+++ b/GCS.WPF/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using GCS.WPF.GShapes;
 
 namespace GCS.WPF
 {
@@ -20,11 +21,15 @@ namespace GCS.WPF
     {
         private State _currentState;
         private Point _lastDownedPoint;
-        private Shape _drawingShape;
+        private GShape _drawingShape;
+
+        private List<GShape> _shapes;
+
         public MainWindow()
         {
             InitializeComponent();
             _currentState = State.NOTDRAWING;
+            _shapes = new List<GShape>();
         }
 
         private void Shape_Toggle(object sender, RoutedEventArgs e)
@@ -56,13 +61,13 @@ namespace GCS.WPF
                 if (_drawingShape == null)
                 {
                     if (_currentState.HasFlag(State.CIRCLE))
-                        _drawingShape = new Ellipse();
+                        _drawingShape = new GEllipse();
                     else if (_currentState.HasFlag(State.LINE))
-                        _drawingShape = new Line();
+                        _drawingShape = new GLine();
                     else if (_currentState.HasFlag(State.DOT))
-                        _drawingShape = new Ellipse();
-                    _drawingShape.Stroke = Brushes.Blue;
-                    shapeCanvas.Children.Add(_drawingShape);
+                        _drawingShape = new GEllipse();
+                    _drawingShape.Control.Stroke = Brushes.Blue;
+                    shapeCanvas.Children.Add(_drawingShape.Control);
                 }
             }
         }
@@ -77,21 +82,22 @@ namespace GCS.WPF
             // Preview drawing
             if (_currentState.HasFlag(State.CIRCLE))
             {
-                (_drawingShape as Ellipse).SetCircle(_lastDownedPoint, curPos);
+                (_drawingShape.Control as Ellipse).SetCircle(_lastDownedPoint, curPos);
             }
             else if (_currentState.HasFlag(State.LINE))
             {
-                (_drawingShape as Line).SetTwoPoint(_lastDownedPoint, curPos);
+                (_drawingShape.Control as Line).SetTwoPoint(_lastDownedPoint, curPos);
             }
             else if (_currentState.HasFlag(State.DOT))
             {
-                (_drawingShape as Ellipse).SetDot(curPos);
+                (_drawingShape.Control as Ellipse).SetDot(curPos);
             }
         }
 
         private void Canvas_MouseUp(object sender, MouseButtonEventArgs e)
         {
             _currentState &= ~State.LEFTMOUSE_DOWN;
+            _shapes.Add(_drawingShape);
             _drawingShape = null; // 요거 없으면 새로 생성안함
         }
     }


### PR DESCRIPTION
거의 비슷하지만, 이전 GCS에서 ShapeRule을 상속하고 반복적으로 작성해야 했던 코드들을 전부 ShapeRule에서 처리하게끔 바꿔서 코드 스멜을 제거. 구조는 거의 비슷하지만 훨씬 더 깨끗하고 새로운 규칙을 추가하기 편함.

하지만 아직 좌표 프로퍼티와 실제로 그려지는 도형 컨트롤의 좌표는 동기화되지 않음. 이거는 GCS에서 Shape가 바로 그려져서 이전에는 별 문제가 아니었지만 이번에는 원래 있던 Shape를 사용하는거니까 좀 빡세게 구현해야할 거 같아 보임.